### PR TITLE
feat: support tooltip on call-to-action

### DIFF
--- a/cypress/e2e/01-block-call-to-action.cy.js
+++ b/cypress/e2e/01-block-call-to-action.cy.js
@@ -27,4 +27,50 @@ describe('Blocks Tests', () => {
     cy.contains('My Add-on Page');
     cy.get('.block.call-to-action');
   });
+
+  it('Add Block: With Tooltip', () => {
+    // Change page title
+    cy.get('[contenteditable=true]').first().clear();
+    cy.get('[contenteditable=true]').first().type('My Tooltip Page');
+    cy.get('.documentFirstHeading').contains('My Tooltip Page');
+    cy.get('[contenteditable=true]').first().type('{enter}');
+
+    // Add Call to Action block
+    cy.get('.ui.basic.icon.button.block-add-button').first().click();
+    cy.get('.blocks-chooser .title').contains('Common').click();
+    cy.get('.content.active.common .button.callToActionBlock').contains('Call to Action').click();
+
+    // Configure the block - set label
+    cy.get('.block.callToAction.selected input[name="field-text"]')
+      .clear()
+      .type('Click Me');
+
+    // Set tooltip via sidebar
+    cy.get('.block.callToAction.selected input[name="field-tooltip"]')
+      .clear()
+      .type('This is a helpful tooltip');
+
+    // Save the page
+    cy.get('#toolbar-save').click();
+    cy.url().should('eq', Cypress.config().baseUrl + '/cypress/my-page');
+
+    // Verify the tooltip appears on hover
+    cy.get('.block.call-to-action .ui.button').contains('Click Me').should('be.visible');
+    
+    // Trigger hover to show tooltip
+    cy.get('.block.call-to-action .ui.button').contains('Click Me').trigger('mouseenter');
+    cy.get('.ui.popup').contains('This is a helpful tooltip').should('be.visible');
+    
+    // Hide tooltip
+    cy.get('.block.call-to-action .ui.button').contains('Click Me').trigger('mouseleave');
+    cy.get('.ui.popup').should('not.be.visible');
+
+    // Verify the tooltip appears on keyboard focus
+    cy.get('.block.call-to-action .ui.button').contains('Click Me').focus();
+    cy.get('.ui.popup').contains('This is a helpful tooltip').should('be.visible');
+    
+    // Blur to hide tooltip
+    cy.get('.block.call-to-action .ui.button').contains('Click Me').blur();
+    cy.get('.ui.popup').should('not.be.visible');
+  });
 });

--- a/cypress/e2e/01-block-call-to-action.cy.js
+++ b/cypress/e2e/01-block-call-to-action.cy.js
@@ -17,7 +17,9 @@ describe('Blocks Tests', () => {
     // Add block
     cy.get('.ui.basic.icon.button.block-add-button').first().click();
     cy.get('.blocks-chooser .title').contains('Common').click();
-    cy.get('.content.active.common .button.callToActionBlock').contains('Call to Action').click();
+    cy.get('.content.active.common .button.callToActionBlock')
+      .contains('Call to Action')
+      .click();
 
     // Save
     cy.get('#toolbar-save').click();
@@ -38,39 +40,39 @@ describe('Blocks Tests', () => {
     // Add Call to Action block
     cy.get('.ui.basic.icon.button.block-add-button').first().click();
     cy.get('.blocks-chooser .title').contains('Common').click();
-    cy.get('.content.active.common .button.callToActionBlock').contains('Call to Action').click();
+    cy.get('.content.active.common .button.callToActionBlock')
+      .contains('Call to Action')
+      .click();
 
-    // Configure the block - set label
-    cy.get('.block.callToAction.selected input[name="field-text"]')
-      .clear()
-      .type('Click Me');
+    cy.get('#sidebar-properties').within(() => {
+      cy.get('input#field-text[name="text"]')
+        .should('be.visible')
+        .clear({ force: true })
+        .type('Click Me', { force: true });
 
-    // Set tooltip via sidebar
-    cy.get('.block.callToAction.selected input[name="field-tooltip"]')
-      .clear()
-      .type('This is a helpful tooltip');
+      cy.get('input#field-tooltip[name="tooltip"]')
+        .should('be.visible')
+        .clear({ force: true })
+        .type('This is a helpful tooltip', { force: true });
+    });
 
     // Save the page
     cy.get('#toolbar-save').click();
     cy.url().should('eq', Cypress.config().baseUrl + '/cypress/my-page');
 
-    // Verify the tooltip appears on hover
-    cy.get('.block.call-to-action .ui.button').contains('Click Me').should('be.visible');
-    
-    // Trigger hover to show tooltip
-    cy.get('.block.call-to-action .ui.button').contains('Click Me').trigger('mouseenter');
-    cy.get('.ui.popup').contains('This is a helpful tooltip').should('be.visible');
-    
-    // Hide tooltip
-    cy.get('.block.call-to-action .ui.button').contains('Click Me').trigger('mouseleave');
-    cy.get('.ui.popup').should('not.be.visible');
+    cy.contains('.block.call-to-action .ui.button', 'Click Me')
+      .should('be.visible')
+      .as('ctaBtn');
 
-    // Verify the tooltip appears on keyboard focus
-    cy.get('.block.call-to-action .ui.button').contains('Click Me').focus();
-    cy.get('.ui.popup').contains('This is a helpful tooltip').should('be.visible');
-    
-    // Blur to hide tooltip
-    cy.get('.block.call-to-action .ui.button').contains('Click Me').blur();
-    cy.get('.ui.popup').should('not.be.visible');
+    cy.get('@ctaBtn').trigger('mouseover', { force: true });
+
+    cy.get('body')
+      .find('.ui.popup', { timeout: 4000 })
+      .should('be.visible')
+      .and('contain.text', 'This is a helpful tooltip');
+
+    cy.get('@ctaBtn').trigger('mouseout', { force: true });
+
+    cy.get('body').find('.ui.popup').should('not.exist');
   });
 });

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr "In neuem Fenster öffnen"
 
-#. Default: ""
+#. Default: "Open in parent window / frame"
 #: components/Schema
 msgid "Open in parent window / frame"
 msgstr "Im übergeordneten Fenster öffnen"
@@ -92,6 +92,11 @@ msgstr "Primär"
 msgid "Secondary"
 msgstr "Sekundär"
 
+#. Default: "Shown on hover"
+#: components/Schema
+msgid "Shown on hover"
+msgstr ""
+
 #. Default: "Target"
 #: components/Schema
 msgid "Target"
@@ -105,4 +110,9 @@ msgstr "Teritär"
 #. Default: "Theme"
 #: components/Schema
 msgid "Theme"
+msgstr ""
+
+#. Default: "Tooltip"
+#: components/Schema
+msgid "Tooltip"
 msgstr ""

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#. Default: ""
+#. Default: "Open in parent window / frame"
 #: components/Schema
 msgid "Open in parent window / frame"
 msgstr ""
@@ -92,6 +92,11 @@ msgstr ""
 msgid "Secondary"
 msgstr ""
 
+#. Default: "Shown on hover"
+#: components/Schema
+msgid "Shown on hover"
+msgstr ""
+
 #. Default: "Target"
 #: components/Schema
 msgid "Target"
@@ -105,4 +110,9 @@ msgstr ""
 #. Default: "Theme"
 #: components/Schema
 msgid "Theme"
+msgstr ""
+
+#. Default: "Tooltip"
+#: components/Schema
+msgid "Tooltip"
 msgstr ""

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#. Default: ""
+#. Default: "Open in parent window / frame"
 #: components/Schema
 msgid "Open in parent window / frame"
 msgstr ""
@@ -92,6 +92,11 @@ msgstr ""
 msgid "Secondary"
 msgstr ""
 
+#. Default: "Shown on hover"
+#: components/Schema
+msgid "Shown on hover"
+msgstr ""
+
 #. Default: "Target"
 #: components/Schema
 msgid "Target"
@@ -105,4 +110,9 @@ msgstr ""
 #. Default: "Theme"
 #: components/Schema
 msgid "Theme"
+msgstr ""
+
+#. Default: "Tooltip"
+#: components/Schema
+msgid "Tooltip"
 msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#. Default: ""
+#. Default: "Open in parent window / frame"
 #: components/Schema
 msgid "Open in parent window / frame"
 msgstr ""
@@ -92,6 +92,11 @@ msgstr ""
 msgid "Secondary"
 msgstr ""
 
+#. Default: "Shown on hover"
+#: components/Schema
+msgid "Shown on hover"
+msgstr ""
+
 #. Default: "Target"
 #: components/Schema
 msgid "Target"
@@ -105,4 +110,9 @@ msgstr ""
 #. Default: "Theme"
 #: components/Schema
 msgid "Theme"
+msgstr ""
+
+#. Default: "Tooltip"
+#: components/Schema
+msgid "Tooltip"
 msgstr ""

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#. Default: ""
+#. Default: "Open in parent window / frame"
 #: components/Schema
 msgid "Open in parent window / frame"
 msgstr ""
@@ -92,6 +92,11 @@ msgstr ""
 msgid "Secondary"
 msgstr ""
 
+#. Default: "Shown on hover"
+#: components/Schema
+msgid "Shown on hover"
+msgstr ""
+
 #. Default: "Target"
 #: components/Schema
 msgid "Target"
@@ -105,4 +110,9 @@ msgstr ""
 #. Default: "Theme"
 #: components/Schema
 msgid "Theme"
+msgstr ""
+
+#. Default: "Tooltip"
+#: components/Schema
+msgid "Tooltip"
 msgstr ""

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -67,7 +67,7 @@ msgstr "Legătură"
 msgid "Open in new window"
 msgstr "Deschide în fereastră nouă"
 
-#. Default: ""
+#. Default: "Open in parent window / frame"
 #: components/Schema
 msgid "Open in parent window / frame"
 msgstr "Deschide în tab nou"
@@ -92,6 +92,11 @@ msgstr "Primară"
 msgid "Secondary"
 msgstr "Secundară"
 
+#. Default: "Shown on hover"
+#: components/Schema
+msgid "Shown on hover"
+msgstr ""
+
 #. Default: "Target"
 #: components/Schema
 msgid "Target"
@@ -106,3 +111,8 @@ msgstr "Terțiară"
 #: components/Schema
 msgid "Theme"
 msgstr "Temă"
+
+#. Default: "Tooltip"
+#: components/Schema
+msgid "Tooltip"
+msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-07-13T09:02:58.528Z\n"
+"POT-Creation-Date: 2026-02-09T12:35:32.584Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#. Default: ""
+#. Default: "Open in parent window / frame"
 #: components/Schema
 msgid "Open in parent window / frame"
 msgstr ""
@@ -94,6 +94,11 @@ msgstr ""
 msgid "Secondary"
 msgstr ""
 
+#. Default: "Shown on hover"
+#: components/Schema
+msgid "Shown on hover"
+msgstr ""
+
 #. Default: "Target"
 #: components/Schema
 msgid "Target"
@@ -107,4 +112,9 @@ msgstr ""
 #. Default: "Theme"
 #: components/Schema
 msgid "Theme"
+msgstr ""
+
+#. Default: "Tooltip"
+#: components/Schema
+msgid "Tooltip"
 msgstr ""

--- a/src/components/Schema.js
+++ b/src/components/Schema.js
@@ -84,6 +84,14 @@ const messages = defineMessages({
     defaultMessage:
       'If enabled, the file linked will be downloaded instead of opened',
   },
+  Tooltip: {
+    id: 'Tooltip',
+    defaultMessage: 'Tooltip',
+  },
+  TooltipDescription: {
+    id: 'Shown on hover',
+    defaultMessage: 'Shown on hover',
+  },
 });
 
 export const EditSchema = ({ intl }) => ({
@@ -93,7 +101,7 @@ export const EditSchema = ({ intl }) => ({
     {
       id: 'default',
       title: 'Default',
-      fields: ['text', 'href', 'download', 'target'],
+      fields: ['text', 'href', 'tooltip', 'download', 'target'],
     },
   ],
 
@@ -105,6 +113,10 @@ export const EditSchema = ({ intl }) => ({
     href: {
       title: intl.formatMessage(messages.Link),
       widget: 'call_to_action',
+    },
+    tooltip: {
+      title: intl.formatMessage(messages.Tooltip),
+      description: intl.formatMessage(messages.TooltipDescription),
     },
     download: {
       title: intl.formatMessage(messages.Download),

--- a/src/components/Schema.js
+++ b/src/components/Schema.js
@@ -69,7 +69,7 @@ const messages = defineMessages({
   },
   TargetParent: {
     id: 'Open in parent window / frame',
-    defineMessages: 'Open in parent window / frame',
+    defaultMessage: 'Open in parent window / frame',
   },
   TargetTop: {
     id: 'Open in top frame (replaces all frames)',

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -68,6 +68,7 @@ const View = ({ data, isEditMode }) => {
           trigger={linkElement}
           position="bottom left"
           wide
+          on={['hover', 'focus']}
         />
       ) : (
         linkElement

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Icon } from 'semantic-ui-react';
+import { Icon, Popup } from 'semantic-ui-react';
 import cx from 'classnames';
 
 import { UniversalLink } from '@plone/volto/components';
@@ -37,26 +37,41 @@ const View = ({ data, isEditMode }) => {
   }, [isEditMode, data.href]);
 
   const url = hasLink && isInternalURL(href) ? flattenToAppURL(href) : href;
+
+  const linkElement = (
+    <UniversalLink
+      className={cx(
+        data.styles?.theme !== 'link' ? 'ui button' : '',
+        data.styles?.inverted ? 'inverted' : '',
+        data.styles?.icon
+          ? data.styles?.rightIcon
+            ? 'icon right labeled'
+            : 'icon left labeled'
+          : '',
+        data.styles?.theme,
+      )}
+      download={data.download}
+      href={url}
+      title={!data.tooltip && hasLink ? data.text : undefined}
+      target={data.target}
+    >
+      <Content data={data} />
+    </UniversalLink>
+  );
+
   return (
     <div className={cx('block call-to-action align', data.styles?.align)}>
-      <UniversalLink
-        className={cx(
-          data.styles?.theme !== 'link' ? 'ui button' : '',
-          data.styles?.inverted ? 'inverted' : '',
-          data.styles?.icon
-            ? data.styles?.rightIcon
-              ? 'icon right labeled'
-              : 'icon left labeled'
-            : '',
-          data.styles?.theme,
-        )}
-        download={data.download}
-        href={url}
-        title={hasLink ? data.text : ''}
-        target={data.target}
-      >
-        <Content data={data} />
-      </UniversalLink>
+      {data.tooltip ? (
+        <Popup
+          basic
+          content={data.tooltip}
+          trigger={linkElement}
+          position="bottom left"
+          wide
+        />
+      ) : (
+        linkElement
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Ticket refs #296805

This PR adds optional tooltip support on call-to-action.
A new schema field allows defining tooltip text, which is shown on hover.